### PR TITLE
Reduce opacity when not playing.

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -19,5 +19,9 @@
             <default>false</default>
             <label>Allow media seeking using the mouse scroll wheel.</label>
         </entry>
+        <entry name="showPlayStateIcon" type="Bool">
+            <default>true</default>
+            <label>Show icon next to label with current play state.</label>
+        </entry>
     </group>
 </kcfg>

--- a/package/contents/ui/CompactRepresentation.qml
+++ b/package/contents/ui/CompactRepresentation.qml
@@ -85,6 +85,7 @@ MouseArea {
         }
 
         Kirigami.Icon {
+            visible: root.playStateIcon
             id: icon
             color: Kirigami.Theme.textColor
             implicitHeight: Math.min(compactRepresentation.height, Kirigami.Units.iconSizes.medium)

--- a/package/contents/ui/CompactRepresentation.qml
+++ b/package/contents/ui/CompactRepresentation.qml
@@ -99,7 +99,7 @@ MouseArea {
             maximumLineCount: 1
             elide: Text.ElideRight
             Layout.maximumWidth: root.maxWidth - icon.width
-            opacity: root.isPlaying ? 1 : 0.3
+            opacity: !root.isPlaying && !root.playStateIcon ? 0.6 : 1
         }
 
         PC3.Label {

--- a/package/contents/ui/CompactRepresentation.qml
+++ b/package/contents/ui/CompactRepresentation.qml
@@ -98,6 +98,7 @@ MouseArea {
             maximumLineCount: 1
             elide: Text.ElideRight
             Layout.maximumWidth: root.maxWidth - icon.width
+            opacity: root.isPlaying ? 1 : 0.3
         }
 
         PC3.Label {

--- a/package/contents/ui/configGeneral.qml
+++ b/package/contents/ui/configGeneral.qml
@@ -27,6 +27,7 @@ import org.kde.kcmutils as KCM
 
 KCM.SimpleKCM {
     property alias cfg_useWheelForSeeking: scrollSeekCheckBox.checked
+    property alias cfg_showPlayStateIcon: showPlayStateIconCheckBox.checked
     property alias cfg_maximumWidth: widthSlider.value
     property alias cfg_minimumWidth: widthSlider.from
     property string cfg_preferredSource: sources.displayText
@@ -37,6 +38,11 @@ KCM.SimpleKCM {
         CheckBox {
             id: scrollSeekCheckBox
             text: i18n("Use scroll wheel for seeking")
+        }
+
+        CheckBox {
+            id: showPlayStateIconCheckBox
+            text: i18n("Show icon with current media play state")
         }
 
         Kirigami.Separator {

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -30,6 +30,7 @@ PlasmoidItem {
     id: root
 
     property bool seekingWheel: Plasmoid.configuration.useWheelForSeeking
+    property bool playStateIcon: Plasmoid.configuration.showPlayStateIcon
     property int minWidth: Plasmoid.configuration.minimumWidth
     property int maxWidth: Plasmoid.configuration.maximumWidth
     property string preferredSource: Plasmoid.configuration.preferredSource


### PR DESCRIPTION
Like the title says, this change reduces the opacity when not playing. Comparison screenshots below. I thought about making it configurable but decided not to. Though I'm willing to make that change if you'd prefer.

when playing:
![playing](https://github.com/panagiotopoulos/MediaBar/assets/29166402/f835075f-9fbf-4e01-9bf0-cfcd050278df)

when not playing:
![not_playing](https://github.com/panagiotopoulos/MediaBar/assets/29166402/6d4b8b90-fe3a-459d-89b6-ac5c78ab14d2)
